### PR TITLE
Halogen.IO.Driver: guard re-entrant render' under the GHC-JS scheduler

### DIFF
--- a/src/Halogen/IO/Driver.hs
+++ b/src/Halogen/IO/Driver.hs
@@ -97,48 +97,72 @@ runUI RenderSpec {..} c i = do
     render' lchs var =
       readIORef var >>= \ds -> do
         shouldProcessHandlers <- isNothing <$> readIORef ds.pendingHandlers
-        when shouldProcessHandlers $ atomicWriteIORef ds.pendingHandlers (Just [])
-        atomicWriteIORef ds.childrenOut Slot.empty
-        atomicWriteIORef ds.childrenIn ds.children
+        if not shouldProcessHandlers
+          then
+            -- Re-entrancy guard. A render is already in progress on THIS
+            -- DriverState (pendingHandlers is non-empty). Under the GHC-JS
+            -- cooperative scheduler the in-progress render yields at the reuse
+            -- path's `evalM (Receive)` below, letting a state-change- or
+            -- fork-triggered re-render re-enter here. Running the render body now
+            -- would walk the VDom against a half-consumed slot set and re-mint
+            -- still-live children (re-creating their DOM + restarting their timers
+            -- — e.g. the splash fade timer never fires, so the splash never
+            -- closes). Instead just flag the in-progress render to run another
+            -- pass: it re-reads the latest state, so the requested render is never
+            -- lost. PureScript's Aff driver never preempts mid-render and so needs
+            -- no such guard; the GHC-JS scheduler does.
+            atomicWriteIORef ds.renderDirty True
+          else do
+            -- Render passes repeat until no re-entrant render was requested. Each
+            -- pass holds the pendingHandlers lock (Just …) across the whole walk
+            -- + handler drain, so any re-entrant render observes the lock and only
+            -- sets renderDirty rather than corrupting this walk.
+            let renderPass = do
+                  atomicWriteIORef ds.pendingHandlers (Just [])
+                  atomicWriteIORef ds.renderDirty False
+                  -- Re-read for the latest state / children / rendering each pass.
+                  cur <- readIORef var
+                  -- Per-render scratch storage, local to this pass; never shared
+                  -- DriverState fields (a re-entrant pass would clobber them).
+                  childrenInRef <- newIORef cur.children
+                  childrenOutRef <- newIORef Slot.empty
 
-        let -- The following 3 defs are working around a capture bug, see #586
-            -- pendingHandlers = identity ds.pendingHandlers
-            -- pendingQueries = identity ds.pendingQueries
-            -- selfRef = identity ds.selfRef
+                  let handler :: Input act -> m ()
+                      handler = Eval.queueOrRun ds.pendingHandlers . void . Eval.evalF render' ds.selfRef
 
-            handler :: Input act -> m ()
-            handler = Eval.queueOrRun ds.pendingHandlers . void . Eval.evalF render' ds.selfRef
+                      childHandler :: act -> m ()
+                      childHandler = Eval.queueOrRun ds.pendingQueries . handler . Input.Action
 
-            childHandler :: act -> m ()
-            childHandler = Eval.queueOrRun ds.pendingQueries . handler . Input.Action
+                  rendering <-
+                    render
+                      handler
+                      (renderChild' lchs childHandler childrenInRef childrenOutRef)
+                      (cur.component.render cur.state)
+                      cur.rendering
 
-        rendering <-
-          render
-            handler
-            (renderChild' lchs childHandler ds.childrenIn ds.childrenOut)
-            (ds.component.render ds.state)
-            ds.rendering
+                  children <- readIORef childrenOutRef
+                  childrenIn <- readIORef childrenInRef
 
-        children <- readIORef ds.childrenOut
-        childrenIn <- readIORef ds.childrenIn
+                  Slot.foreachSlot childrenIn $ \(DriverStateRef childVar) -> do
+                    childDS <- DriverStateX <$> readIORef childVar
+                    renderStateX_ removeChild childDS
+                    finalize lchs childDS
 
-        Slot.foreachSlot childrenIn $ \(DriverStateRef childVar) -> do
-          childDS <- DriverStateX <$> readIORef childVar
-          renderStateX_ removeChild childDS
-          finalize lchs childDS
+                  atomicModifyIORef'_ ds.selfRef $ \ds' ->
+                    ds' {rendering = Just rendering, children = children}
 
-        atomicModifyIORef'_ ds.selfRef $ \ds' ->
-          ds' {rendering = Just rendering, children = children}
+                  flip loopM () $ \_ -> do
+                    handlers <- readIORef ds.pendingHandlers
+                    atomicWriteIORef ds.pendingHandlers (Just [])
+                    traverse_ (traverse_ fork . reverse) handlers
+                    mmore <- readIORef ds.pendingHandlers
+                    if maybe False null mmore
+                      then atomicWriteIORef ds.pendingHandlers Nothing $> Right ()
+                      else pure $ Left ()
 
-        when shouldProcessHandlers $ do
-          flip loopM () $ \_ -> do
-            handlers <- readIORef ds.pendingHandlers
-            atomicWriteIORef ds.pendingHandlers (Just [])
-            traverse_ (traverse_ fork . reverse) handlers
-            mmore <- readIORef ds.pendingHandlers
-            if maybe False null mmore
-              then atomicWriteIORef ds.pendingHandlers Nothing $> Right ()
-              else pure $ Left ()
+                  dirty <- readIORef ds.renderDirty
+                  when dirty renderPass
+            renderPass
 
     renderChild'
       :: forall ps act

--- a/src/Halogen/IO/Driver/State.hs
+++ b/src/Halogen/IO/Driver/State.hs
@@ -33,13 +33,16 @@ data DriverState m r s f act ps i o = DriverState
   , state :: s
   , refs :: Map Text Element
   , children :: SlotStorage ps (DriverStateRef m r)
-  , childrenIn :: IORef (SlotStorage ps (DriverStateRef m r))
-  , childrenOut :: IORef (SlotStorage ps (DriverStateRef m r))
   , selfRef :: IORef (DriverState m r s f act ps i o)
   , handlerRef :: IORef (o -> m ())
   , pendingQueries :: IORef (Maybe [m ()])
   , pendingOuts :: IORef (Maybe [m ()])
   , pendingHandlers :: IORef (Maybe [m ()])
+  , -- | Set when a render is requested re-entrantly while one is already in
+    -- progress on this DriverState (see @render'@ in "Halogen.IO.Driver"). The
+    -- in-progress render re-runs its walk once it observes this, so a render
+    -- triggered by a state change that lands mid-render is never dropped.
+    renderDirty :: IORef Bool
   , rendering :: Maybe (r s act ps o)
   , fresh :: IORef Int
   , subscriptions :: IORef (Maybe (Map SubscriptionId (HS.Subscription m)))
@@ -89,12 +92,11 @@ initDriverState
   -> m (DriverState m r s f act ps i o)
 initDriverState component input handler lchs = do
   selfRef <- newIORef (fix identity)
-  childrenIn <- newIORef SlotStorage.empty
-  childrenOut <- newIORef SlotStorage.empty
   handlerRef <- newIORef handler
   pendingQueries <- newIORef (Just [])
   pendingOuts <- newIORef (Just [])
   pendingHandlers <- newIORef Nothing
+  renderDirty <- newIORef False
   fresh <- newIORef 1
   subscriptions <- newIORef (Just mempty)
   forks <- newIORef mempty
@@ -105,13 +107,12 @@ initDriverState component input handler lchs = do
           , state
           , refs = mempty
           , children = SlotStorage.empty
-          , childrenIn
-          , childrenOut
           , selfRef
           , handlerRef
           , pendingQueries
           , pendingOuts
           , pendingHandlers
+          , renderDirty
           , rendering = Nothing
           , fresh
           , subscriptions


### PR DESCRIPTION
### Symptom

Under GHC-JS, a component whose render forks a timer (e.g. a splash-screen fade) can reach a state where child slots' DOM **accumulates** across renders, the `Halogen: Duplicate slot address was detected during rendering` warning fires repeatedly, and the forked timers **restart every render** so they never fire (the splash never closes).

### Root cause

`render'` reset the **shared** `DriverState.childrenIn` / `childrenOut` fields at the start of every render and then walked the VDom. Under the GHC-JS **cooperative** scheduler, the reuse path's `evalM (Receive)` yields, letting a state-change- or fork-triggered re-render **re-enter `render'` on the same `DriverState`**. The nested render reset the shared scratch and drained `childrenIn`; when the outer walk resumed, the slot set was empty, so it **re-minted still-live children** — new DOM plus restarted forks.

PureScript's Aff driver never preempts mid-render, so the port inherited a latent bug that only manifests under the GHC-JS scheduler.

### Fix

- New `DriverState.renderDirty :: IORef Bool`. While a render is in progress (`pendingHandlers` non-empty), a re-entrant `render'` only **sets** `renderDirty` and returns; the in-progress render loops its passes — re-reading the latest state each pass — until `renderDirty` is clear. Nothing is dropped, nothing corrupts the in-flight walk. (An earlier attempt that *enqueued + forked* the deferred render livelocked; a single dirty flag + synchronous re-run is correct.)
- `childrenIn` / `childrenOut` are now `newIORef`'d **per render pass** (locals) rather than shared `DriverState` fields, so a re-entrant pass can't clobber them. The two fields were removed.

### Testing

This is a GHC-JS **scheduler-interleaving** bug; native GHC's RTS won't reproduce the exact mid-render yield, so there is no faithful native unit test. It was diagnosed via instrumented driver traces (`render'` ENTER/EXIT + `Slot.pop` HIT/MISS) and verified in headless Chrome: with the fix the splash fades through both logos and closes (~13 s, matching the PS timing), with no duplicate-slot warning and no DOM accumulation. Happy to add a CHANGELOG entry on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
